### PR TITLE
Adapter v1 slack adapter continue conversation

### DIFF
--- a/slack_adapter/slack_adapter.py
+++ b/slack_adapter/slack_adapter.py
@@ -8,7 +8,9 @@ from .slack_helper import SlackHelper
 from slack_adapter import NewSlackMessage, slack_helper
 from logging import Logger
 
+
 class SlackAdapter:
+
     @property
     def __options(self):
         return self._options
@@ -64,6 +66,17 @@ class SlackAdapter:
         pass
 
     async def send_activities(self, turn_context: TurnContext, activities: list[Activity], cancellation_token):
+
+        """
+
+        # Standard BotBuilder adapter method to send a message from the bot to the messaging API.
+        # param name="turnContext" A TurnContext representing the current incoming message and environment.
+        # param name="activities" An array of outgoing activities to be sent back to the messaging API.
+        # param name="cancellationToken" A cancellation token for the task.
+        # Returns an array of see cref="ResourceResponse" objects containing the IDs that Slack assigned to the sent messages.
+
+        """
+
         if turn_context is None:
             ValueError(type(turn_context))
 
@@ -93,6 +106,13 @@ class SlackAdapter:
         return responses
 
     async def update_activity(self, turn_context: TurnContext, activity: Activity, cancellation_token):
+
+        """
+        # param name = "turnContext" A TurnContext representing the current incoming message and environment
+        # param name = "activity" The updated activity in the form '{id: `id of activity to update`, ...}'
+        # param name = "cancellationToken" A cancellation token for the task
+        """
+
         if turn_context is None:
             ValueError(type(turn_context))
 
@@ -121,6 +141,14 @@ class SlackAdapter:
         return resource_response
 
     async def delete_activity(self, turn_context: TurnContext, reference: ConversationReference, cancellation_token):
+
+        """
+           # param name="turnContext" A TurnContext representing the current incoming message and environment.
+           # param name="reference" An object in the form
+           "{activityId: `id of message to delete`, conversation: { id: `id of slack channel`}}"
+           # param name="cancellationToken" A cancellation token for the task
+        """
+
         if turn_context is None:
             ValueError(type(turn_context))
 

--- a/slack_adapter/slack_adapter.py
+++ b/slack_adapter/slack_adapter.py
@@ -62,7 +62,18 @@ class SlackAdapter:
 
         return message
 
-    def continue_conversation(self, reference: ConversationReference):
+    @dispatch()
+    def continue_conversation(self, reference: ConversationReference, logic, cancellation_token):
+        if not reference:
+            raise Exception("reference")
+
+        if not logic:
+            raise Exception("logic")
+
+
+
+    @dispatch()
+    def continue_conversation(self, claims_identity, reference: ConversationReference, callback, cancellation_token):
         pass
 
     async def send_activities(self, turn_context: TurnContext, activities: list[Activity], cancellation_token):

--- a/slack_adapter/slack_adapter.py
+++ b/slack_adapter/slack_adapter.py
@@ -1,5 +1,4 @@
-from multipledispatch import dispatch
-from logging import
+from logging import Logger
 from typing import List
 
 from botbuilder.core import TurnContext, BotAdapter
@@ -51,7 +50,7 @@ class SlackAdapter(BotAdapter):
         self._logger = logger
 
     @staticmethod
-    def activity_to_slack(activity:Activity):
+    def activity_to_slack(activity: Activity):
         channel_id = activity.conversation.id
         thread_time_stamp = activity.conversation.thread_time_stamp
 

--- a/slack_adapter/slack_client_wrapper.py
+++ b/slack_adapter/slack_client_wrapper.py
@@ -326,12 +326,24 @@ class SlackClientWrapper:
         """
         return await self._api.auth_test().user_id
 
-    async def update(self, channel, ts):
+    async def update(self, ts: str, channel_id: str, text: str = '', bot_name: str = '', parse: str = '',
+                     link_names: bool = False, attachments=None, as_user: bool = False):
         """
-
+            Wraps Slack API's UpdateAsync method
+            @param ts: The timestamp of the message.
+            @param channel_id: The channel to delete the message from.
+            @param text: The text to update with.
+            @param bot_name: The optional bot name.
+            @param parse: Change how messages are treated.Defaults to 'none'.
+            @param link_names: f to find and link channel names and username.
+            @param attachments: The attachments, if any.
+            @param as_user: If the message is being sent as user instead of as a bot.
+            @param cancellation_token: A cancellation token for the task.
+            @rtype: SlackResponse
+            @returns: The SlackResponse to the posting operation.
         """
-        # ToDo: to I have to update the chat here?
-        return await self._api.chat_update(channel=channel, ts=ts)
+        return await self._api.chat_update(channel='', ts=ts, channel_id=channel_id, bot_name=bot_name, parse=parse,
+                                           link_names=link_names, attachments=attachments, as_user=as_user)
 
     async def upload_file(self, file, content):
         """


### PR DESCRIPTION
In the Slack Adapter class we have a multi method called Continue Conversation, we removed it from the class and instead use BotAdapter (that already has Continue Conversation ported) in Slack Adapter class